### PR TITLE
cancel the rownames before calling tibble::column_to_rownames()

### DIFF
--- a/R/graphs.R
+++ b/R/graphs.R
@@ -206,6 +206,7 @@ algii_heatmap <- function(data, nk, E, clusters, ref.cl = NULL) {
   ii <- ivi_table(fc, data)
 
   # Heatmap: order algorithms by ranked ii, remove indices with NaN
+  row.names(ii) <- NULL # because otherwise column_to_rownames() fails
   hm <- ii %>%
     tibble::column_to_rownames("Algorithms") %>%
     magrittr::extract(match(consensus_rank(ii, 1)$top.list, rownames(.)),


### PR DESCRIPTION
diceR was identified by CRAN as a package that potentially was broken by the upcoming release of `dplyr`: https://github.com/tidyverse/dplyr/issues/5599

it does not seem strictly related to dplyr though. 

This pull request deals with one issue about calling `tibble::column_to_rownames()` on a tibble that already has row names, which fails here: https://github.com/tidyverse/tibble/blob/dd29fb76b6b0335a08658c14483fe3cbb81cf7d7/R/rownames.R#L94

ping @krlmlr perhaps this is too strict ? in the meantime the pull request is harmless. 

Another issue is potentially fixed by this: https://github.com/biagio-incardona/clValid/pull/1

There are also other issues that I can't fix. I hope this gets you started :-)