### PR TITLE
CI: make checks diagnostic again when blockcluster is unavailable

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,10 +42,14 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            blockcluster=?ignore
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
+        env:
+          _R_CHECK_FORCE_SUGGESTS_: false
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2
+          extra-packages: |
+            any::covr
+            any::xml2
+            blockcluster=?ignore
           needs: coverage
 
       - name: Test coverage


### PR DESCRIPTION
This PR makes the GitHub Actions checks more diagnostic when the optional package `blockcluster` is unavailable in CI.

## Why
The current workflows can fail during dependency setup before the actual package checks run. In practice that turns the CI signal into a repository-level setup failure rather than a useful indicator of whether a PR introduced a regression.

The package already treats `blockcluster` as optional in code and tests, so the workflows can be narrowed accordingly.

## What changes
- tell `setup-r-dependencies` to ignore `blockcluster` when resolving extra packages
- allow missing suggested packages during `R CMD check`
- leave package code and tests unchanged

## Files
- `.github/workflows/R-CMD-check.yaml`
- `.github/workflows/test-coverage.yaml`

## Validation
- YAML syntax check passed locally for both workflow files
- the same branch passed all GitHub Actions checks on my fork after this workflow change

## Scope
This PR only changes CI workflow behavior. There is no package-code change.

Thanks for maintaining the package and for considering this change.
